### PR TITLE
added tag props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Tag props to widget.
+
 ## [2.1.0] - 2021-08-02
 
 ### Added

--- a/docs/README.md
+++ b/docs/README.md
@@ -82,6 +82,7 @@ To use widget without `shop-review-badge` to landing pages, for example, you can
 |  `height`  | `string` | Change height of template |  `undefined`   |
 |  `theme`  | `string` | Change theme of template `light` or `dark` |  `undefined`   |
 |  `stars`  | `string` | Change stars stock of template |  `undefined`   |
+|  `tag`  | `string` | Filter reviews based on tag |  `undefined`   |
 |  `businessUnitId`  | `string` | Set your business code  |  `undefined`  |
 |  `templateId`  | `string` | Set your template ID  | `5419b6a8b0d04a076446a9ad`  |
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -82,7 +82,7 @@ To use widget without `shop-review-badge` to landing pages, for example, you can
 |  `height`  | `string` | Change height of template |  `undefined`   |
 |  `theme`  | `string` | Change theme of template `light` or `dark` |  `undefined`   |
 |  `stars`  | `string` | Change stars stock of template |  `undefined`   |
-|  `tag`  | `string` | Filter reviews based on tag |  `undefined`   |
+|  `tag`  | `string` | Change tag of template |  `undefined`   |
 |  `businessUnitId`  | `string` | Set your business code  |  `undefined`  |
 |  `templateId`  | `string` | Set your template ID  | `5419b6a8b0d04a076446a9ad`  |
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -82,7 +82,7 @@ To use widget without `shop-review-badge` to landing pages, for example, you can
 |  `height`  | `string` | Change height of template |  `undefined`   |
 |  `theme`  | `string` | Change theme of template `light` or `dark` |  `undefined`   |
 |  `stars`  | `string` | Change stars stock of template |  `undefined`   |
-|  `tag`  | `string` | Change tag of template |  `undefined`   |
+|  `tag`  | `string` | Change tag of template. More info [here](https://support.trustpilot.com/hc/en-us/articles/203840856-Tag-your-service-reviews) |  `undefined`   |
 |  `businessUnitId`  | `string` | Set your business code  |  `undefined`  |
 |  `templateId`  | `string` | Set your template ID  | `5419b6a8b0d04a076446a9ad`  |
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -68,6 +68,7 @@ To use widget without `shop-review-badge` to landing pages, for example, you can
          "height":"240px",
          "theme":"light",
          "stars":"4,5",
+         "tag":"cart",
          "businessUnitId":"597a23fwffdsfe05a793fe",
          "templateId":"5419b6a8b0d04a076446a9ad"
       }

--- a/messages/context.json
+++ b/messages/context.json
@@ -6,5 +6,6 @@
   "admin/editor.trustpilot.theme": "Theme",
   "admin/editor.trustpilot.width": "Width",
   "admin/editor.trustpilot.height": "Height",
-  "admin/editor.trustpilot.stars": "Stars"
+  "admin/editor.trustpilot.stars": "Stars",
+  "admin/editor.trustpilot.tag": "Tag"
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -6,5 +6,6 @@
   "admin/editor.trustpilot.theme": "Theme",
   "admin/editor.trustpilot.width": "Width",
   "admin/editor.trustpilot.height": "Height",
-  "admin/editor.trustpilot.stars": "Stars"
+  "admin/editor.trustpilot.stars": "Stars",
+  "admin/editor.trustpilot.tag": "Tag"
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -6,5 +6,6 @@
   "admin/editor.trustpilot.theme": "Tema",
   "admin/editor.trustpilot.width": "Ancho",
   "admin/editor.trustpilot.height": "Alto",
-  "admin/editor.trustpilot.stars": "Estrellas"
+  "admin/editor.trustpilot.stars": "Estrellas",
+  "admin/editor.trustpilot.tags": "Etiqueta"
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -7,5 +7,5 @@
   "admin/editor.trustpilot.width": "Ancho",
   "admin/editor.trustpilot.height": "Alto",
   "admin/editor.trustpilot.stars": "Estrellas",
-  "admin/editor.trustpilot.tags": "Etiqueta"
+  "admin/editor.trustpilot.tag": "Etiqueta"
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -6,5 +6,6 @@
   "admin/editor.trustpilot.theme": "Tema",
   "admin/editor.trustpilot.width": "Largura",
   "admin/editor.trustpilot.height": "Altura",
-  "admin/editor.trustpilot.stars": "Estrelas"
+  "admin/editor.trustpilot.stars": "Estrelas",
+  "admin/editor.trustpilot.tags": "Marcação"
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -7,5 +7,5 @@
   "admin/editor.trustpilot.width": "Largura",
   "admin/editor.trustpilot.height": "Altura",
   "admin/editor.trustpilot.stars": "Estrelas",
-  "admin/editor.trustpilot.tags": "Marcação"
+  "admin/editor.trustpilot.tag": "Marcação"
 }

--- a/react/Widget.tsx
+++ b/react/Widget.tsx
@@ -9,6 +9,7 @@ interface Props {
   width: string
   height: string
   stars: string
+  tag: string
 }
 
 const Widget: StorefrontFunctionComponent<Props> = ({
@@ -19,6 +20,7 @@ const Widget: StorefrontFunctionComponent<Props> = ({
   width,
   height,
   stars,
+  tag,
   baseUrl = 'https://www.trustpilot.com/review',
 }) => {
   const ref = useRef(null)
@@ -49,6 +51,7 @@ const Widget: StorefrontFunctionComponent<Props> = ({
       data-style-width={width}
       data-style-height={height}
       data-stars={stars}
+      data-tags={tag}
     >
       <a
         href={`${baseUrl}/${storeDomain}`}
@@ -93,6 +96,10 @@ Widget.schema = {
     },
     stars: {
       title: 'admin/editor.trustpilot.stars',
+      type: 'string',
+    },
+    tag: {
+      title: 'admin/editor.trustpilot.tag',
       type: 'string',
     },
   },

--- a/react/Widget.tsx
+++ b/react/Widget.tsx
@@ -9,7 +9,7 @@ interface Props {
   width: string
   height: string
   stars: string
-  tag: string
+  tag?: string
 }
 
 const Widget: StorefrontFunctionComponent<Props> = ({


### PR DESCRIPTION
**What problem is this solving?**
We can filter the reviews based on a tag and display it at site.  Eg: In idville account, we want to display a template tagged by cart in cart page alone.

<!--- What is the motivation and context for this change? -->
We can filter the reviews based on a tag and display it at site.  Eg: In idville account, we want to display a template tagged by cart in cart page alone.

**Screenshots or example usage:**

The above functionality can be tested in this(https://trustpilot--idville.myvtex.com/cart) workspace.

![Screenshot 2022-09-15 at 10 44 33 AM](https://user-images.githubusercontent.com/86110961/190320192-a5d5b136-6609-45f8-bd49-bfd10681242c.png)
