### PR TITLE
Update trustpilot version in Readme instructions.

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -54,7 +54,7 @@ To use widget without `shop-review-badge` to landing pages, for example, you can
 
 ```diff
  "peerDependencies": {
-+   "vtex.trustpilot": "1.x"
++   "vtex.trustpilot": "2.x"
  }
 ```
 ## `trustpilot-widget` as props


### PR DESCRIPTION
Fix the version for the dependencies, so the agencies can't implement without falling into errors.

**What problem is this solving?**

Readme instructions outdated with old version.

<!--- What is the motivation and context for this change? -->

Agencies following the documentation without being able to implement it and receiving errors.

**How should this be manually tested?**

N/A

**Screenshots or example usage:**

N/A